### PR TITLE
IVFPQ with 4-bit quantizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Several datasets can be downloaded at once by `python download.py --multirun dat
 | deep1m    |  96 | 1,000,000 | 10,000 | 100,000 | The first 1M vectors of [Deep1B](https://github.com/arbabenko/GNOIMI). [Hepler scripts](https://github.com/matsui528/deep1b_gt)|
 
 ## Supported Algorithms
-- [linear scan (faiss)](https://github.com/facebookresearch/faiss)
-- [ivfpq (faiss)](https://github.com/facebookresearch/faiss)
+- [linear scan (faiss)](https://github.com/facebookresearch/faiss/blob/master/faiss/IndexFlat.h)
+- [ivfpq (faiss)](https://github.com/facebookresearch/faiss/blob/master/faiss/IndexIVFPQ.h)
+- [ivfpq with 4-bit pq (faiss)](https://github.com/facebookresearch/faiss/blob/master/faiss/IndexIVFPQFastScan.h)
 - [annoy](https://github.com/spotify/annoy)
 - [hnsw](https://github.com/nmslib/hnswlib)
 

--- a/annbench/algo/ivfpq.py
+++ b/annbench/algo/ivfpq.py
@@ -45,3 +45,10 @@ class IvfpqANN(BaseANN):
     def stringify_index_param(self, param):
         return f"M{param['M']}_nlist{param['nlist']}.bin"
 
+
+class Ivfpq4bitANN(IvfpqANN):
+    def train(self, vecs):
+        D = vecs.shape[1]
+        quantizer = faiss.IndexFlatL2(D)
+        self.index = faiss.IndexIVFPQFastScan(quantizer, D, self.nlist, self.M, 4)
+        self.index.train(vecs)

--- a/annbench/algo/proxy.py
+++ b/annbench/algo/proxy.py
@@ -1,5 +1,5 @@
 from .annoy import AnnoyANN
-from .ivfpq import IvfpqANN
+from .ivfpq import IvfpqANN, Ivfpq4bitANN
 from .hnsw import HnswANN
 from .linear import LinearANN
 from .linear_gpu import LinearGpuANN
@@ -27,6 +27,8 @@ def instantiate_algorithm(name):
         return LinearGpuANN()
     elif name == "ivfpq_gpu":
         return IvfpqGpuANN()
+    elif name =="ivfpq4bit":
+        return Ivfpq4bitANN()
     else:
         return None
 

--- a/conf/algo/ivfpq4bit.yaml
+++ b/conf/algo/ivfpq4bit.yaml
@@ -1,0 +1,17 @@
+# @package _group_
+
+name: ivfpq4bit
+
+param_index:
+  - M: 16
+    nlist: 100
+  - M: 32
+    nlist: 100
+
+param_query:
+  nprobe:
+    - 1
+    - 2
+    - 4
+    - 8
+    - 16

--- a/conf/specialized_param/deep1m_ivfpq4bit.yaml
+++ b/conf/specialized_param/deep1m_ivfpq4bit.yaml
@@ -1,0 +1,7 @@
+# @package _global_
+algo:
+  param_index:
+    - M: 24
+      nlist: 1000
+    - M: 48
+      nlist: 1000

--- a/conf/specialized_param/sift1m_ivfpq4bit.yaml
+++ b/conf/specialized_param/sift1m_ivfpq4bit.yaml
@@ -1,0 +1,7 @@
+# @package _global_
+algo:
+  param_index:
+    - M: 32
+      nlist: 1000
+    - M: 64
+      nlist: 1000


### PR DESCRIPTION
- Implemented the latest 4-bit quantizer (without [re-ranking](https://github.com/facebookresearch/faiss/wiki/Implementation-notes#reranking) such as [this line](https://github.com/facebookresearch/faiss/blob/master/benchs/bench_all_ivf/cmp_with_scann.py#L278))
- [class](https://github.com/facebookresearch/faiss/blob/master/faiss/IndexIVFPQFastScan.h)
- [detail](https://github.com/facebookresearch/faiss/wiki/Implementation-notes#the-4-bit-pq-fast-scan-implementation-in-faiss)
- [bench](https://github.com/facebookresearch/faiss/wiki/Indexing-1M-vectors#4-bit-pq-comparison-with-scann)

The distance computation of PQ is accelerated by in-register look-up. The above benchmark reported that this 4-bit PQ achieved a comparative performance to Google SCANN. 

However, I cannot reproduce such an impressive result. I may miss something?